### PR TITLE
fix: extends errors on eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,6 @@
         "eject": "react-scripts eject",
         "start-server:dev": "nodemon server/index.js"
     },
-    "eslintConfig": {
-        "extends": [
-            "react-app",
-            "react-app/jest",
-            "prettier"
-        ]
-    },
     "browserslist": {
         "production": [
             ">0.2%",


### PR DESCRIPTION
- there was no need to have this in the `pkg.json` since we have a separate file for it