### PR TITLE
Config / Refine the weekly email reports

### DIFF
--- a/server/cron/healthFactor.ts
+++ b/server/cron/healthFactor.ts
@@ -14,7 +14,7 @@ type EmailItem = {
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-function formatAddress(address: string): string {
+function shortenAddress(address: string) {
     return `${address.slice(0, 5)}...${address.slice(-4)}`
 }
 
@@ -121,7 +121,7 @@ const sendEmailsToAllContacts = async () => {
         for (const { protectedDataAddress, owner, content } of emailItems) {
             await Promise.race([
                 sendMail(protectedDataAddress, {
-                    subject: `Weekly health update on ${formatAddress(owner)}'s loans`,
+                    subject: `Weekly health update on ${shortenAddress(owner)}'s loans`,
                     content
                 }).then(() => console.log(`Email sent to ${owner}`)),
                 new Promise((_, reject) =>

--- a/server/cron/healthFactor.ts
+++ b/server/cron/healthFactor.ts
@@ -85,8 +85,9 @@ const sendEmailsToAllContacts = async () => {
 
                 const content = `
                         <div>
-                            <p>Hey,</p>
-                            <p>With the precision of a hawk scanning the horizon 🦅, here’s a quick update for <strong>${owner}</strong>'s open positions as of ${utcTime.toLocaleString(
+                            <p>Hey!</p>
+                            ${healthFactorContent}
+                            <p>That's the quick update for <strong>${owner}</strong>'s positions as of ${utcTime.toLocaleString(
                                 'en-GB',
                                 {
                                     day: 'numeric',
@@ -95,11 +96,9 @@ const sendEmailsToAllContacts = async () => {
                                     hour: 'numeric',
                                     minute: 'numeric'
                                 }
-                            )} UTC:</p>
-                            ${healthFactorContent}
-                            <p>PS: More stats available on your dashboard at <a href="https://safe-hawk.com">safe-hawk.com</a></p>
-                            <p>Have a great week,</p>
-                            <p>SafeHawk team.</p>
+                            )} UTC.</p>
+                            <p>For more stats and insights, visit your dashboard: <a href="https://safe-hawk.com">safe-hawk.com</a></p>
+                            <p>Speak to you next Monday!<br />The SafeHawk Team 🦅</p>
                         </div>
                     `
 

--- a/server/cron/healthFactor.ts
+++ b/server/cron/healthFactor.ts
@@ -14,6 +14,10 @@ type EmailItem = {
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+function formatAddress(address: string): string {
+    return `${address.slice(0, 5)}...${address.slice(-4)}`
+}
+
 const fetchHealthFactorContent = async (owner: string) => {
     const healthFactorPromises = NETWORKS.map(({ chainId, name, aaveLendingPoolAddress }) => ({
         chainId,
@@ -118,7 +122,7 @@ const sendEmailsToAllContacts = async () => {
         for (const { protectedDataAddress, owner, content } of emailItems) {
             await Promise.race([
                 sendMail(protectedDataAddress, {
-                    subject: 'Health Factor report by SafeHawk',
+                    subject: `Weekly health update on ${formatAddress(owner)}'s loans`,
                     content
                 }).then(() => console.log(`Email sent to ${owner}`)),
                 new Promise((_, reject) =>

--- a/server/cron/healthFactor.ts
+++ b/server/cron/healthFactor.ts
@@ -84,7 +84,7 @@ const sendEmailsToAllContacts = async () => {
                 const utcTime = new Date(date.getTime() + date.getTimezoneOffset() * 60000)
 
                 const content = `
-                        <div>
+                        <div style="font-family: trebuchet ms, sans-serif">
                             <p>Hey!</p>
                             ${healthFactorContent}
                             <p>That's the quick update for <strong>${owner}</strong>'s positions as of ${utcTime.toLocaleString(


### PR DESCRIPTION
Tweaks a bit the texts of the weekly email reports:

- Changed: Lowercase subject (looks more casual), tweak text (highlight regularity with "weekly"), and add a subset of the owner address (looks cool)
- Changed: Move the important info (health factor) upfront. Bonus: this way it may appear in Gmail's preview lines (depends on the screen size and user settings).
- Changed: Footer text now highlighting regularity (Speak to you next Monday!)
- Changed: The font-family to trebuchet ms (one of the Gmail defaults) that I use and love (opinionated). Looks a little more pimped than raw now.